### PR TITLE
Fix test suite identifier typo

### DIFF
--- a/stats_test.cc
+++ b/stats_test.cc
@@ -5,11 +5,11 @@
 #include "stats.h"
 #include "gtest/gtest.h"
 
-TEST(ProptTest, ValidInput) {
+TEST(PropTest, ValidInput) {
     EXPECT_DOUBLE_EQ(PropTest(14, 100, 20, 100), 0.25870176105718945);
 }
 
-TEST(ProptTest, InvalidInput) {
+TEST(PropTest, InvalidInput) {
     EXPECT_EQ(PropTest(0, 0, 0, 0), -1);
 }
 


### PR DESCRIPTION
## Summary
- rename `ProptTest` test suite to `PropTest`

## Testing
- `bazel test //:stats_test` *(fails: command produced no output)*

------
https://chatgpt.com/codex/tasks/task_e_6895fa82ad20832a85f0c7c7c08d1d0b